### PR TITLE
Remove export of grasp_detector library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,6 @@ generate_messages(DEPENDENCIES geometry_msgs sensor_msgs std_msgs)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 INCLUDE_DIRS include
-LIBRARIES grasp_detector 
 CATKIN_DEPENDS cmake_modules eigen_conversions geometry_msgs message_runtime roscpp sensor_msgs std_msgs
 DEPENDS Eigen OpenCV PCL
 )


### PR DESCRIPTION
There is no library named grasp_detector. Maybe you meant to export gpd_grasp_detector?