### PR TITLE
OpenVINO classifier: enable GPU support

### DIFF
--- a/src/gpd/openvino_classifier.cpp
+++ b/src/gpd/openvino_classifier.cpp
@@ -57,8 +57,9 @@ OpenVINOClassifier::OpenVINOClassifier(Classifier::Device device)
     network_reader.ReadWeights(std::string(MODELS_DIR) + "/fp16/single_view_15_channels.bin");
     break;
   case Classifier::Device::eGPU:
-    std::cout << "GPU device to be supported!!\n";
-    // fall through;
+    network_reader.ReadNetwork(std::string(MODELS_DIR) + "/fp16/single_view_15_channels.xml");
+    network_reader.ReadWeights(std::string(MODELS_DIR) + "/fp16/single_view_15_channels.bin");
+    break;
   case Classifier::Device::eFPGA:
     std::cout << "FPGA device to be supported!!\n";
     // fall through;

--- a/tutorials/tutorial_openvino.md
+++ b/tutorials/tutorial_openvino.md
@@ -1,15 +1,25 @@
-# Tutorial Enable OpenVINO
+# Tutorial Enable OpenVINO™ (Open Visual Inference & Neural Network Optimization)
 
-In this tutorial, we introduce how to enable OpenVINO option for grasp detection.
+In this tutorial, we introduce how to enable [OpenVINO™](https://software.intel.com/en-us/openvino-toolkit)
+option for grasp detection. Based on convolutional neural networks (CNN),
+the toolkit extends workloads across Intel® hardware and maximizes performance.
 
-## 1. Install OpenVINO toolkit
-OpenVINO supports multiple host OS. We verified with Linux.
-[Installing the OpenVINO Toolkit for Linux](https://software.intel.com/en-us/articles/OpenVINO-Install-Linux)
+## 1. Install OpenVINO™ toolkit
+OpenVINO supports multiple host OS. We verified with 64-bit Ubuntu 16.04.
 
-## 2. Verify OpenVINO installation
-Try to run the demo scripts.
-[Verify the Demo Scripts](https://software.intel.com/en-us/articles/OpenVINO-Install-Linux#inpage-nav-3-5)
-Then try to run OpenVINO inference example applications.
+For gpd execution at Intel CPU, please follow the
+[Installing the OpenVINO™ Toolkit for Linux](https://software.intel.com/en-us/articles/OpenVINO-Install-Linux).
+
+For gpd execution at Intel GPU, please follow additional steps to install OpenCL NEO driver
+[Additional Installation Steps for Processor Graphics (GPU)](https://software.intel.com/en-us/articles/OpenVINO-Install-Linux#inpage-nav-4-1).
+
+For gpd execution at Intel Movidius NCS, please follow additional steps to configure UDEV rules.
+[Additional Installation Steps for the Intel® Movidius™ Neural Compute Stick](https://software.intel.com/en-us/articles/OpenVINO-Install-Linux#inpage-nav-4-2).
+
+## 2. Verify OpenVINO™ installation
+Try to run the demo scripts: [Verify the Demo Scripts](https://software.intel.com/en-us/articles/OpenVINO-Install-Linux#inpage-nav-3-5)
+
+Then try to run OpenVINO inference example applications:
 [Build the Samples](https://software.intel.com/en-us/articles/OpenVINO-InferEngine#inpage-nav-6),
 [Running the Samples](https://software.intel.com/en-us/articles/OpenVINO-InferEngine#inpage-nav-7)
 


### PR DESCRIPTION
    This patch enable GPU support in the OpenVINOClassifier.
    It is verified on a 6th gen Core-i7 platform.

    $ roslaunch gpd tutorial1.launch device:=1

Signed-off-by: Sharron LIU <sharron.liu@intel.com>