### PR TITLE
Fix compiling error caused by lto option on Ubuntu 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(gpd)
 set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_STANDARD 14)
+SET(CMAKE_AR  "gcc-ar")
+SET(CMAKE_RANLIB "gcc-ranlib")
+SET(CMAKE_NM "gcc-nm")
 
 # Eigen library
 include_directories(${EIGEN3_INCLUDE_DIR})


### PR DESCRIPTION
Fix the issue in : https://github.com/atenpas/gpd/issues/107