### PR TITLE
Adding support for python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,3 +301,38 @@ set_target_properties(${PROJECT_NAME}_grasp_detector
 install(TARGETS ${PROJECT_NAME}_grasp_detector DESTINATION lib)
 
 install(DIRECTORY include/gpd DESTINATION include)
+
+option(BUILD_PYTHON "build python bindings" OFF)
+if(BUILD_PYTHON STREQUAL "ON")
+    # Python bindings
+    message("Building python bindings, need pybind11 to be in build's parent directory")
+    message("https://github.com/pybind/pybind11")
+    add_subdirectory(pybind11)
+    pybind11_add_module(gpd_python SHARED src/pybind.cpp)
+    target_link_libraries(gpd_python PRIVATE
+        ${PROJECT_NAME}_grasp_detector
+        ${PROJECT_NAME}_classifier
+        ${PROJECT_NAME}_clustering
+        ${PROJECT_NAME}_sequential_importance_sampling
+        ${PROJECT_NAME}_antipodal
+        ${PROJECT_NAME}_candidates_generator
+        ${PROJECT_NAME}_finger_hand
+        ${PROJECT_NAME}_frame_estimator
+        ${PROJECT_NAME}_hand
+        ${PROJECT_NAME}_hand_set
+        ${PROJECT_NAME}_hand_geometry
+        ${PROJECT_NAME}_hand_search
+        ${PROJECT_NAME}_local_frame
+        ${PROJECT_NAME}_cloud
+        ${PROJECT_NAME}_config_file
+        ${PROJECT_NAME}_eigen_utils
+        ${PROJECT_NAME}_plot
+        ${PROJECT_NAME}_point_list
+        ${PROJECT_NAME}_image_strategy
+        ${PROJECT_NAME}_image_1_channels_strategy
+        ${PROJECT_NAME}_image_3_channels_strategy
+        ${PROJECT_NAME}_image_12_channels_strategy
+        ${PROJECT_NAME}_image_15_channels_strategy
+        ${PROJECT_NAME}_image_geometry
+        ${PROJECT_NAME}_image_generator)
+endif()

--- a/filter.py
+++ b/filter.py
@@ -1,0 +1,34 @@
+try:
+    # This has to come before the open3d import for some reason?
+    # https://github.com/isl-org/Open3D/issues/1428
+    import gpd_python as gpd
+except ImportError:
+    print("Couldn't find gpd_python library.")
+import numpy as np
+import time
+import open3d as o3d
+import klampt
+from klampt.io import numpy_convert
+from klampt import vis
+
+detector = gpd.GraspDetector("cfg/eigen_params.cfg")
+pcd = o3d.io.read_point_cloud("orig_full.pcd")
+cl, _ = pcd.remove_statistical_outlier(nb_neighbors=30,
+                                                std_ratio=1.0)
+print(len(pcd.points), len(cl.points))
+o3d.visualization.draw_geometries([pcd])
+o3d.visualization.draw_geometries([cl])
+# pcd = cl
+# pts = np.asarray(pcd.points)
+# pts = pts[np.logical_not(np.isnan(pts[:, 0])), :]
+# # tf = np.array([
+# #     [0, 0, -1, 1],
+# #     [0, 1,  0, 0],
+# #     [1, 0,  0, 0],
+# #     [0, 0,  0, 1]
+# # ])
+# tf = np.eye(4)
+# pts = (tf @ (np.hstack(( pts, np.ones((len(pts), 1)) ))).T).T[:, :3]
+# offset = np.mean(pts, axis=0, keepdims=True)
+# grasps = gpd.detectGrasps(detector, pts - offset, np.zeros(3))
+# print(grasps)

--- a/include/gpd/util/cloud.h
+++ b/include/gpd/util/cloud.h
@@ -138,6 +138,12 @@ class Cloud {
 
   /**
    * \brief Constructor.
+   * \param cloud the point cloud (of size n)
+   */
+  Cloud(const PointCloudRGB::Ptr &cloud);
+
+  /**
+   * \brief Constructor.
    * \param cloud the point cloud with surface normals (of size n)
    * \param camera_source the camera source for each point in the cloud (size: k
    * x n)

--- a/src/gpd/util/cloud.cpp
+++ b/src/gpd/util/cloud.cpp
@@ -32,6 +32,20 @@ Cloud::Cloud(const PointCloudRGB::Ptr &cloud,
   *cloud_processed_ = *cloud_original_;
 }
 
+Cloud::Cloud(const PointCloudRGB::Ptr &cloud)
+    : cloud_processed_(new PointCloudRGB),
+      cloud_original_(new PointCloudRGB) {
+  view_points_.resize(3, 1);
+  view_points_ << 0.0, 0.0, 0.0;
+  sample_indices_.resize(0);
+  samples_.resize(3, 0);
+  normals_.resize(3, 0);
+
+  pcl::copyPointCloud(*cloud, *cloud_original_);
+  *cloud_processed_ = *cloud_original_;
+  camera_source_ = Eigen::MatrixXi::Ones(1, cloud_processed_->size());
+}
+
 Cloud::Cloud(const PointCloudPointNormal::Ptr &cloud,
              const Eigen::MatrixXi &camera_source,
              const Eigen::Matrix3Xd &view_points)

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -42,7 +42,7 @@ pybind11::array_t<double> detectGrasps(
         cloud_ptr->push_back(pt);
     }
     Eigen::MatrixXi visibility = Eigen::MatrixXi::Ones(1, len);
-    Eigen::Matrix3Xd view_points;
+    Eigen::Matrix3Xd view_points(3,1);
     for(ssize_t i = 0; i < 3; i++){
         view_points(i) = camera.at(i);
     }

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -17,9 +17,17 @@
 // 3 for position, 9 for orientation, 1 for width, 1 for score
 #define GRASP_DESC_LEN 14
 
+/**
+ *  Detect grasps from a given point cloud
+ *  pcd: (n,3), each row is a point in the cloud
+ *  visibility: (num_cams, n), each row is a camera, each column j denotes if
+ *      the corresponding point is visible from the given camera.
+ *  camera: (3, num_cams), each column j is the position of the camera.
+ */
 pybind11::array_t<double> detectGrasps(
     gpd::GraspDetector &detector,
     pybind11::array_t<double, pybind11::array::c_style> pcd,
+    pybind11::array_t<double, pybind11::array::c_style> visibility,
     pybind11::array_t<double, pybind11::array::c_style> camera)
 {
     if (pcd.ndim() != 2) {
@@ -32,6 +40,7 @@ pybind11::array_t<double> detectGrasps(
     if (pcd.shape()[1] < 3) {
         throw std::invalid_argument("Each point must have at least 3 coordinates");
     }
+    ssize_t num_cams = camera.shape()[1];
     pcl::PointCloud<pcl::PointXYZRGBA> e_cloud;
     pcl::PointCloud<pcl::PointXYZRGBA>::Ptr cloud_ptr = e_cloud.makeShared();
     for(ssize_t i = 0; i < len; i++){
@@ -41,12 +50,19 @@ pybind11::array_t<double> detectGrasps(
         pt.z = pcd.at(i, 2);
         cloud_ptr->push_back(pt);
     }
-    Eigen::MatrixXi visibility = Eigen::MatrixXi::Ones(1, len);
-    Eigen::Matrix3Xd view_points(3,1);
-    for(ssize_t i = 0; i < 3; i++){
-        view_points(i) = camera.at(i);
+    Eigen::MatrixXi vis(num_cams, len);
+    for(ssize_t i = 0; i < num_cams; i++){
+        for (ssize_t j = 0; j < len; j++){
+            vis(i, j) = visibility.at(i, j);
+        }
     }
-    gpd::util::Cloud gpd_cloud(cloud_ptr, visibility, view_points);
+    Eigen::Matrix3Xd view_points(3, num_cams);
+    for(ssize_t i = 0; i < 3; i++){
+        for(ssize_t j = 0; j < num_cams; j++){
+            view_points(i, j) = camera.at(i, j);
+        }
+    }
+    gpd::util::Cloud gpd_cloud(cloud_ptr, vis, view_points);
     detector.preprocessPointCloud(gpd_cloud);
     std::vector<std::unique_ptr<gpd::candidate::Hand>> grasps = detector.detectGrasps(gpd_cloud);
     std::vector<std::array<double, GRASP_DESC_LEN>> ret;

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -1,0 +1,66 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <Eigen/Dense>
+#include <string>
+#include <vector>
+#include <array>
+#include <memory>
+#include <stdexcept>
+#include <iostream>
+#include "../include/gpd/grasp_detector.h"
+#include "../include/gpd/util/cloud.h"
+#include "../include/gpd/candidate/hand.h"
+
+// 3 for position, 9 for orientation, 1 for width, 1 for score
+#define GRASP_DESC_LEN 14
+
+pybind11::array_t<double> detectGrasps(
+    gpd::GraspDetector &detector,
+    pybind11::array_t<double, pybind11::array::c_style> pcd)
+{
+    // TODO: Make these conditions raise actual exceptions
+    if (pcd.ndim() != 2) {
+        throw std::invalid_argument("PCD must have two dimensions");
+    }
+    ssize_t len = pcd.shape()[0];
+    if (len == 0) {
+        throw std::invalid_argument("PCD must more than 0 points");
+    }
+    if (pcd.shape()[1] < 3) {
+        throw std::invalid_argument("Each point must have at least 3 coordinates");
+    }
+    pcl::PointCloud<pcl::PointXYZRGBA> e_cloud;
+    pcl::PointCloud<pcl::PointXYZRGBA>::Ptr cloud_ptr = e_cloud.makeShared();
+    for(ssize_t i = 0; i < len; i++){
+        pcl::PointXYZRGBA pt(pcd.at(i, 0), pcd.at(i, 1), pcd.at(i, 2));
+        cloud_ptr->push_back(pt);
+    }
+    gpd::util::Cloud gpd_cloud(cloud_ptr);
+    detector.preprocessPointCloud(gpd_cloud);
+    std::vector<std::unique_ptr<gpd::candidate::Hand>> grasps = detector.detectGrasps(gpd_cloud);
+    std::vector<std::array<double, GRASP_DESC_LEN>> ret;
+    for(size_t i = 0; i < grasps.size(); i++){
+        const Eigen::Vector3d pos = grasps[i]->getPosition();
+        const Eigen::Matrix3d rot = grasps[i]->getOrientation();
+        const double w = grasps[i]->getGraspWidth();
+        const double score = grasps[i]->getScore();
+        std::array<double, GRASP_DESC_LEN> gd = {
+            pos[0], pos[1], pos[2],
+            rot(0,0), rot(0,1), rot(0,2),
+            rot(1,0), rot(1,1), rot(1,2),
+            rot(2,0), rot(2,1), rot(2,2),
+            w, score
+        };
+        ret.push_back(gd);
+    }
+    return pybind11::cast(ret);
+}
+
+PYBIND11_MODULE(gpd_python, m) {
+    pybind11::class_<gpd::GraspDetector>(m, "GraspDetector")
+        .def(pybind11::init<const std::string &>());
+    m.def("detectGrasps", &detectGrasps);
+}

--- a/test.py
+++ b/test.py
@@ -1,5 +1,3 @@
-
-import open3d as o3d
 try:
     # This has to come before the open3d import for some reason?
     # https://github.com/isl-org/Open3D/issues/1428
@@ -7,16 +5,44 @@ try:
 except ImportError:
     print("Couldn't find gpd_python library.")
 import numpy as np
+import time
+import open3d as o3d
+import klampt
+from klampt.io import numpy_convert
+from klampt import vis
 
 detector = gpd.GraspDetector("cfg/eigen_params.cfg")
-pcd = o3d.io.read_point_cloud("tutorials/krylon.pcd")
+pcd = o3d.io.read_point_cloud("save.pcd")
 pts = np.asarray(pcd.points)
-tf = np.array([
-    [0, 0, -1, 1],
-    [0, 1,  0, 0],
-    [1, 0,  0, 0],
-    [0, 0,  0, 1]
-])
+pts = pts[np.logical_not(np.isnan(pts[:, 0])), :]
+# tf = np.array([
+#     [0, 0, -1, 1],
+#     [0, 1,  0, 0],
+#     [1, 0,  0, 0],
+#     [0, 0,  0, 1]
+# ])
+tf = np.eye(4)
 pts = (tf @ (np.hstack(( pts, np.ones((len(pts), 1)) ))).T).T[:, :3]
-grasps = gpd.detectGrasps(detector, pts - np.mean(pts, axis=0, keepdims=True))
+offset = np.mean(pts, axis=0, keepdims=True)
+grasps = gpd.detectGrasps(detector, pts - offset, np.zeros(3))
 print(grasps)
+k_pcd = klampt.PointCloud()
+for i in range(len(pts)):
+    k_pcd.addPoint(pts[i, :])
+world = klampt.WorldModel()
+vis.add("pcd", k_pcd)
+for i in range(len(grasps)):
+    g: np.ndarray = grasps[i, :]
+    pos = g[:3] + offset   # Undo mean subtraction
+    rot = g[3:12].reshape(3, 3)
+    # # Flip GPD convention to our convention
+    # rot = rot @ np.array([
+    #     [-1,  0, 0],
+    #     [ 0, -1, 0],
+    #     [ 0,  0, 1]
+    # ])
+    k_tf = (rot.T.flatten().tolist(), pos.reshape(-1).tolist())
+    vis.add("grasp_{}".format(i), k_tf)
+vis.show()
+while vis.shown():
+    time.sleep(0.05)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,22 @@
+
+import open3d as o3d
+try:
+    # This has to come before the open3d import for some reason?
+    # https://github.com/isl-org/Open3D/issues/1428
+    import gpd_python as gpd
+except ImportError:
+    print("Couldn't find gpd_python library.")
+import numpy as np
+
+detector = gpd.GraspDetector("cfg/eigen_params.cfg")
+pcd = o3d.io.read_point_cloud("tutorials/krylon.pcd")
+pts = np.asarray(pcd.points)
+tf = np.array([
+    [0, 0, -1, 1],
+    [0, 1,  0, 0],
+    [1, 0,  0, 0],
+    [0, 0,  0, 1]
+])
+pts = (tf @ (np.hstack(( pts, np.ones((len(pts), 1)) ))).T).T[:, :3]
+grasps = gpd.detectGrasps(detector, pts - np.mean(pts, axis=0, keepdims=True))
+print(grasps)

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ from klampt.io import numpy_convert
 from klampt import vis
 
 detector = gpd.GraspDetector("cfg/eigen_params.cfg")
-pcd = o3d.io.read_point_cloud("save.pcd")
+pcd = o3d.io.read_point_cloud("tutorials/krylon.pcd")
 pts = np.asarray(pcd.points)
 pts = pts[np.logical_not(np.isnan(pts[:, 0])), :]
 # tf = np.array([
@@ -24,7 +24,7 @@ pts = pts[np.logical_not(np.isnan(pts[:, 0])), :]
 tf = np.eye(4)
 pts = (tf @ (np.hstack(( pts, np.ones((len(pts), 1)) ))).T).T[:, :3]
 offset = np.mean(pts, axis=0, keepdims=True)
-grasps = gpd.detectGrasps(detector, pts - offset, np.zeros(3))
+grasps = gpd.detectGrasps(detector, pts - offset, np.ones((1, len(pts))), np.zeros((3, 1)))
 print(grasps)
 k_pcd = klampt.PointCloud()
 for i in range(len(pts)):


### PR DESCRIPTION
Can build shared library for python bindings by specifying
-DBUILD_PYTHON=ON when calling cmake. This requires pybind11
to be cloned into build's parent directory. The python bindings
expose a very minimal interface: it allows construction of a
`GraspDetector` and calling `detectGrasps` which accepts a
previously instantiated `GraspDetector` and a point cloud as a
numpy array (of shape (n, 3)). This function returns a numpy
array of shape (number of grasps, 14) where the columns specify
the position, orientation (rotation matrix in row-major order), the width
of the gripper, and the score of the grasp.